### PR TITLE
docs: unify commit messages throughout the textbook

### DIFF
--- a/chapters/cicd_gitlab.md
+++ b/chapters/cicd_gitlab.md
@@ -7,7 +7,7 @@ cd hello_cicd
 echo "hello world" >> .gitlab-ci.yml
 git checkout -b feature/add-ci
 git add .gitlab-ci.yml
-git commit -m "my first ci/cd"
+git commit -m "feat: add GitLab CI/CD pipeline configuration"
 git push -u origin feature/add-ci
 ```
 

--- a/chapters/git_advanced.md
+++ b/chapters/git_advanced.md
@@ -162,7 +162,7 @@ $ git log --oneline -n 2
 ```
 
 ```text
-8cd0fc5 (HEAD -> new_feature, origin/new_feature) changes made
+8cd0fc5 (HEAD -> new_feature, origin/new_feature) feat: add project overview and book link to README
 3b6859d docs: add initial README file with project title
 ```
 
@@ -186,8 +186,8 @@ $ git log --oneline -n 2
 ```
 
 ```text
-a15777d (HEAD -> main, origin/main, origin/HEAD) fixed spelling
-27775a1 Update weekly_assignments.md
+a15777d (HEAD -> main, origin/main, origin/HEAD) fix: correct spelling in README
+27775a1 docs: update weekly assignments
 ```
 
 We have not lost our work:
@@ -201,7 +201,7 @@ $ git log --oneline -n 2
 
 ```text
 
-8cd0fc5 (HEAD -> new_feature, origin/new_feature) changes made
+8cd0fc5 (HEAD -> new_feature, origin/new_feature) feat: add project overview and book link to README
 3b6859d docs: add initial README file with project title
 ```
 
@@ -285,7 +285,7 @@ $ git log --oneline -n 4
 ```text
 5df6f8f (HEAD -> main) Merge branch 'new_feature'
 55178f0 (origin/new_feature, new_feature) docs: add project overview and book link to README
-8cd0fc5 changes made
+8cd0fc5 feat: add project overview and book link to README
 3b6859d docs: add initial README file with project title
 
 ```
@@ -515,8 +515,8 @@ $ git log --oneline -n 4
 ```text
 55c63d0 (HEAD -> main) docs: resolve merge conflict and combine README additions
 45a576b docs: add Contributors section with initial contributor to README
-a0b88e5 (docs) Added repository overview
-232b564 Initial commit of README file
+a0b88e5 (docs) docs: add repository overview to README
+232b564 docs: add initial README file with project title
 ```
 
 If we want to see what really happened, we can add the `--graph` option to `git log`:
@@ -702,8 +702,8 @@ $ git log --oneline -n 4
 55c63d0 (HEAD -> main, origin/main, origin/HEAD) 
         docs: resolve merge conflict and combine README additions
 45a576b docs: add Contributors section with initial contributor to README
-a0b88e5 Added repository overview
-232b564 Initial commit of README file
+a0b88e5 docs: add repository overview to README
+232b564 docs: add initial README file with project title
 ```
 
 You can also see that Git has automatically created a **remote** for their repository that points back at their repository on Gitlab:

--- a/chapters/git_advanced.md
+++ b/chapters/git_advanced.md
@@ -134,11 +134,11 @@ $ echo "# Zipf" > README.md
 
 ```bash
 $ git add README.md
-$ git commit -m "Added readme"
+$ git commit -m "docs: add initial README file with project title"
 ```
 
 ```text
-[new_feature 3b6859d] Added readme
+[new_feature 3b6859d] docs: add initial README file with project title
  1 file changed, 1 insertion(+)
  create mode 100644 zipf/README.md
 ```
@@ -163,7 +163,7 @@ $ git log --oneline -n 2
 
 ```text
 8cd0fc5 (HEAD -> new_feature, origin/new_feature) changes made
-3b6859d Added readme
+3b6859d docs: add initial README file with project title
 ```
 
 (We use `--oneline` and `-n 2` to shorten the log display.) But if we switch back to the `master` branch:
@@ -202,7 +202,7 @@ $ git log --oneline -n 2
 ```text
 
 8cd0fc5 (HEAD -> new_feature, origin/new_feature) changes made
-3b6859d Added readme
+3b6859d docs: add initial README file with project title
 ```
 
 We can also look inside `README.md` and see our changes.
@@ -219,11 +219,11 @@ In this folder you find the necessary data and scripts used in the RSE-UP book t
 
 ```bash
 $ git add README.md
-$ git commit -m "description update"
+$ git commit -m "docs: add project overview and book link to README"
 ```
 
 ```text
-[new_feature 55178f0] description update
+[new_feature 55178f0] docs: add project overview and book link to README
  1 file changed, 2 insertions(+)
 ```
 
@@ -284,9 +284,9 @@ $ git log --oneline -n 4
 
 ```text
 5df6f8f (HEAD -> main) Merge branch 'new_feature'
-55178f0 (origin/new_feature, new_feature) description update
+55178f0 (origin/new_feature, new_feature) docs: add project overview and book link to README
 8cd0fc5 changes made
-3b6859d Added readme
+3b6859d docs: add initial README file with project title
 
 ```
 
@@ -359,11 +359,11 @@ In this folder ....
 
 ```bash
 $ git add README.md
-$ git commit -m "updated readme description"
+$ git commit -m "docs: add Zipf's law description to README"
 ```
 
 ```text
-[docs 0b72d0e] updated readme description
+[docs 0b72d0e] docs: add Zipf's law description to README
  1 file changed, 2 insertions(+)
 ```
 
@@ -402,11 +402,11 @@ In this folder you find the necessary data and scripts used in the RSE-UP book t
 
 ```
 $ git add README.md
-$ git commit -m "Added contributor list"
+$ git commit -m "docs: add Contributors section with initial contributor to README"
 ```
 
 ```text
-[main 885a8c7] Added contributor list
+[main 885a8c7] docs: add Contributors section with initial contributor to README
  1 file changed, 2 insertions(+)
 ```
 
@@ -499,11 +499,11 @@ We can now add the file and commit the change, just as we would after any other 
 
 ```bash
 $ git add README.md
-$ git commit -m "Merging README additions"
+$ git commit -m "docs: resolve merge conflict and combine README additions"
 ```
 
 ```text
-[main 55c63d0] Merging README additions
+[main 55c63d0] docs: resolve merge conflict and combine README additions
 ```
 
 Our branch's history now shows a single sequence of commits, with the `master` changes on top of the earlier `docs` changes:
@@ -513,8 +513,8 @@ $ git log --oneline -n 4
 ```
 
 ```text
-55c63d0 (HEAD -> main) Merging README additions
-45a576b Added contributor list
+55c63d0 (HEAD -> main) docs: resolve merge conflict and combine README additions
+45a576b docs: add Contributors section with initial contributor to README
 a0b88e5 (docs) Added repository overview
 232b564 Initial commit of README file
 ```
@@ -528,8 +528,8 @@ $ git log --oneline --graph -n 4
 ```text
 *   b6954e8 (HEAD -> main) Merge branch 'docs' merge conflict test
 |\
-| * 0b72d0e (docs) updated readme description
-* | 885a8c7 Added contributor list
+| * 0b72d0e (docs) docs: add Zipf's Law script description to README
+* | 885a8c7 docs: add Contributors section with initial contributor to README
 |/
 *   5df6f8f (origin/main, origin/HEAD) Merge branch 'new_feature'
 |\
@@ -700,8 +700,8 @@ $ git log --oneline -n 4
 
 ```text
 55c63d0 (HEAD -> main, origin/main, origin/HEAD) 
-        Merging README additions
-45a576b Added contributor list
+        docs: resolve merge conflict and combine README additions
+45a576b docs: add Contributors section with initial contributor to README
 a0b88e5 Added repository overview
 232b564 Initial commit of README file
 ```
@@ -746,11 +746,11 @@ With this remote in place, you are finally set up. Suppose, for example, that we
 We commit the changes and push them to our repository on Gitlab:
 
 ```bash
-$ git commit -a -m "Adding *you* as a contributor"
+$ git commit -a -m "docs: add yourself to Contributors section in README"
 ```
 
 ```text
-[main 35fca86] Adding you as a contributor
+[main 35fca86] docs: add yourself to Contributors section in README
  1 file changed, 1 insertion(+)
 ```
 
@@ -823,11 +823,11 @@ Switched to a new branch 'adding-email'
 then make a change and commit it:
 
 ```bash
-$ git commit -a -m "Adding my email address"
+$ git commit -a -m "docs: add email address to Contributors section in README"
 ```
 
 ```text
-[adding-email 3e73dc0] Adding my email address
+[adding-email 3e73dc0] docs: add email address to Contributors section in README
  1 file changed, 1 insertion(+), 1 deletion(-)
 ```
 

--- a/chapters/git_advanced_github.md
+++ b/chapters/git_advanced_github.md
@@ -82,10 +82,10 @@ sami:~/zipf $ git log --oneline -n 4
 
 ```text
 55c63d0 (HEAD -> master, origin/master, origin/HEAD) 
-        Merging README additions
-45a576b Added contributor list
-a0b88e5 Added repository overview
-232b564 Initial commit of README file
+        docs: merge README additions from contributors
+45a576b docs: add contributor list to README
+a0b88e5 docs: add repository overview to README
+232b564 docs: add initial README file with project title
 ```
 
 Sami also sees that Git has automatically created a **remote** for their repository that points back at their repository on GitHub:

--- a/chapters/git_advanced_github.md
+++ b/chapters/git_advanced_github.md
@@ -135,11 +135,11 @@ files and plot each word's rank versus its frequency.
 Amira commits her changes and pushes them to *her* repository on GitHub:
 
 ```bash
-amira:~/zipf $ git commit -a -m "Adding Sami as a contributor"
+amira:~/zipf $ git commit -a -m "docs: add Sami Virtanen to Contributors section in README"
 ```
 
 ```text
-[master 35fca86] Adding Sami as a contributor
+[master 35fca86] docs: add Sami Virtanen to Contributors section in README
  1 file changed, 1 insertion(+)
 ```
 
@@ -218,11 +218,11 @@ Switched to a new branch 'adding-email'
 then make a change and commit it:
 
 ```bash
-sami:~/zipf $ git commit -a -m "Adding my email address"
+sami:~/zipf $ git commit -a -m "docs: add email address to Contributors section in README"
 ```
 
 ```text
-[adding-email 3e73dc0] Adding my email address
+[adding-email 3e73dc0] docs: add email address to Contributors section in README
  1 file changed, 1 insertion(+), 1 deletion(-)
 ```
 

--- a/chapters/intro_version_control.md
+++ b/chapters/intro_version_control.md
@@ -245,11 +245,11 @@ We no longer have any untracked files,
 but the tracked files haven't been **committed** (i.e., saved permanently in our project's history). We can do this using `git commit`:
 
 ```bash
-$ git commit -m "Add scripts, novels, word counts, and plots"
+$ git commit -m "feat: Add scripts, novels, word counts, and plots"
 ```
 
 ```text
-[master (root-commit) 173222b] Add scripts, novels, word 
+[master (root-commit) 173222b] feat: add scripts, novels, word 
     counts, and plots
  18 files changed, 145296 insertions(+)
  create mode 100644 bin_pycodestyle/countwords.py
@@ -302,11 +302,11 @@ Changes to be committed:
 We commit this as the starting point of the project's history:
 
 ```bash
-$ git commit -m "Add initial project structure and source files"
+$ git commit -m "feat: add initial project structure and source files"
 ```
 
 ```text
-[main (root-commit) a1b2c3d] Add initial project structure and source files
+[main (root-commit) a1b2c3d] feat: add initial project structure and source files
  13 files changed, 500 insertions(+)
  create mode 100644 .gitignore
  create mode 100644 CITATION.cff
@@ -351,19 +351,13 @@ rather than after we have done some work.
 
 ## Describing Commits
 
-If we run `git commit` *without* the `-m` option, Git opens a text editor so that we can write a longer **commit message**. In this message,
-the first line is referred to as the "subject" and the rest as the "body", just as in an email.
-
-When we use `-m`, we are only writing the subject line; this makes things easier in the short run, but if our project's history fills up with one-liners like "Fixed problem" or "Updated", our future self will wish that we had taken a few extra seconds to explain things in a little more detail.
-Following [these guidelines]( https://chris.beams.io/posts/git-commit/) will help:
-
-1.  Separate the subject from the body with a blank line so that it is easy to spot.
-2.  Limit subject lines to 50 characters so that they are easy to scan.
-3.  Write the subject line in Title Case (like a section heading).
-4.  Do not end the subject line with a period.
-5.  Write as if giving a command (e.g., "Make each plot half the width of the page").
-6.  Wrap the body (i.e., insert line breaks to format text as paragraphs rather than relying on editors to wrap lines automatically).
-7.  Use the body to explain what and why rather than how.
+When we use `-m`, we are only writing the subject line; this makes things easier in the short run, but if our project's history fills up with one-liners like "fixed problem" or "updated", our future self will wish that we had taken a few extra seconds to explain things in a little more detail.
+We follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard, which we cover in detail in the [commit messages chapter](https://se-up.github.io/RSE-UP/chapters/commit_messages.html). In short, every commit message should look like:
+```
+<type>: <short description>
+```
+Where `type` is one of `feat`, `fix`, `docs`, `chore`, `test`, `refactor`, and the description is lowercase and concise.
+A longer body explaining *what* and *why* can be added after a blank line.
 
 > **Which Editor?**
 >
@@ -426,11 +420,11 @@ Let's do that with `git add` and then commit our change:
 
 ```bash
 $ git add hello.txt
-$ git commit -m "Jello World"
+$ git commit -m "chore: add hello.txt as example file"
 ```
 
 ```text
-[master 851d590] Jello World
+[master 851d590] chore: add hello.txt as example file
  1 file changed, 0 insertions(+), 0 deletions(-)
  create mode 100644 hello.txt
 ```
@@ -447,7 +441,7 @@ commit 851d590a214c7859eafa0998c6c951f8e0eb359b (HEAD -> main)
 Author: YOU Yu <email@mail.org>
 Date:   Sat Dec 19 09:32:41 2020 -0800
 
-    Jello World
+    chore: add hello.txt as example file
 
 commit 173222bf90216b408c8997f4e143572b99637750
 Author: You Yu <yuyou@mail.org>
@@ -539,7 +533,7 @@ After reviewing our change
 we can commit it just as we did before:
 
 ```bash
-$ git commit -m "Fixed spelling mistake"
+$ git commit -m "fix: correct spelling mistake in hello.txt"
 ```
 
 ```text
@@ -571,11 +565,11 @@ Changes to be committed:
 ```
 
 ```bash
-$ git commit -m "X Message"
+$ git commit -m "fix: correct spelling mistake in hello.txt"
 ```
 
 ```text
-[main 582f7f6] Plot frequency against rank on log-log axes
+[main 582f7f6] fix: correct spelling mistake in hello.txt
 1 file changed, 1 insertion(+), 1 deletion(-)
 ```
 
@@ -792,13 +786,13 @@ commit ee8684ca123e1e829fc995d672e3d7e4b00f2610
 Author: You Youn <you@mail.org>
 Date:   Sat Dec 19 09:52:04 2020 -0800
 
-    Update test.txt
+    fix: update test.txt
 
 commit 582f7f6f536d520b1328c04c9d41e24b54170656
 Author: You You <you@email.org>
 Date:   Sat Dec 19 09:37:25 2020 -0800
 
-    spelling fix
+    fix: correct spelling mistake in hello.txt
 
 commit 851d590a214c7859eafa0998c6c951f8e0eb359b
 .....
@@ -828,7 +822,7 @@ commit ee8684ca123e1e829fc995d672e3d7e4b00f2610
 Author: You You <you@mail.org>
 Date:   Sat Dec 19 09:52:04 2020 -0800
 
-    Update hello.txt
+    fix: update hello.txt
 
 diff --git a/results/dracula.png b/results/dracula.png
 index c1f62fd..57a7b70 100644


### PR DESCRIPTION
## Summary

- Updated all `git commit` example messages in `git_advanced.md` and `git_advanced_github.md` to follow the Conventional commits standard introduced in the `commit_messages.md` chapter
- Only chapters that appear **after** `commit_messages.md` in the table of contents were updated, as readers would not yet know the convention in earlier chapters

Closes issue #55 